### PR TITLE
added a firewall entry for srun from ctld node to submit hosts

### DIFF
--- a/manifests/firewall.pp
+++ b/manifests/firewall.pp
@@ -56,6 +56,12 @@ class slurm::firewall {
                 source => $network_value,
             }
         }
+        firewall { "0304 slurm srun from ctld_host ${slurm::ctld_host}":
+            dport  => '60001-63000',
+            proto  => tcp,
+            action => accept,
+            source => $slurm::ctld_host,
+        }
     }
 
     if $slurm::is_worker_node {


### PR DESCRIPTION
Comment in commit. This change was made because srun /salloc does not work for interactive jobs without these ports being open from the ctld node.